### PR TITLE
the holy edit. deleting a trailing slash

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -12,7 +12,7 @@ const port = process.env.PORT || 3000;
 
 // Enable CORS for all routes
 app.use(cors({
-  origin: ['https://research-finder-1000.web.app/', 'http://localhost:5173'], // Replace with your front-end's domain
+  origin: ['https://research-finder-1000.web.app', 'http://localhost:5173'], // Replace with your front-end's domain
   methods: 'GET,POST,PUT,DELETE', // Customize as needed
   credentials: true    // Enable this if you need to include cookies
 }));


### PR DESCRIPTION
great idea moron.

essentiallly: the cors policy states: origin: ['https://research-finder-1000.web.app/', 'http://localhost:5173'], // Replace with your front-end's domain

but the URL we acess from is : https://research-finder-1000.web.app


chat gipity says remove the slashes so i must be a genius
